### PR TITLE
#167326110 Enables a user to reset forgotten password

### DIFF
--- a/NCPWD/apps/authentication/urls.py
+++ b/NCPWD/apps/authentication/urls.py
@@ -3,7 +3,10 @@ from django.urls import path
 from .views import (
     LoginAPIView,
     RegistrationAPIView,
-    AccountVerificationView)
+    AccountVerificationView,
+    ForgotPasswordView,
+    ResetPasswordView
+    )
 
 app_name = "authentication"
 
@@ -14,4 +17,10 @@ urlpatterns = [
     path(
         'account/verify/<str:token>/<str:uid>/',
         AccountVerificationView.as_view(), name='activate-account'),
+    path(
+        'password/forgot/',
+        ForgotPasswordView.as_view(), name="forgot-password"),
+    path(
+        'password/reset/<str:token>/',
+        ResetPasswordView.as_view(), name="reset-password"),
 ]

--- a/NCPWD/apps/core/client.py
+++ b/NCPWD/apps/core/client.py
@@ -6,8 +6,15 @@ def get_domain():
 
 
 def get_activation_link(token, uid):
-    """
-    :rtype: object
-    """
     return "{}/{}?token={}&uid={}".format(
         get_domain(), os.getenv("CLIENT_ACTIVATE_ACCOUNT_ROUTE"), token, uid)
+
+
+def get_login_link():
+    return "/login".format(get_domain(), os.getenv(
+            "LOGIN_ROUTE"))
+
+
+def get_password_reset_link(token):
+    return "{}/{}?token={}".format(get_domain(), os.getenv(
+            "CLIENT_RESET_PASSWORD_ROUTE"), token)

--- a/NCPWD/settings.py
+++ b/NCPWD/settings.py
@@ -160,4 +160,3 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
-

--- a/templates/email_verification.html
+++ b/templates/email_verification.html
@@ -10,7 +10,7 @@
     </p>
 </div>
 <div style="box-sizing: border-box;">
-    <a href={{activation_link}}> <button type=" button" class="btn btn-primary" style="box-sizing: border-box;border-radius: 4px;margin: 0;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;overflow: visible;text-transform: none;-webkit-appearance: button;display: inline-block;font-weight: 400;text-align: center;white-space: nowrap;vertical-align: middle;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;border: 1px solid transparent;padding: .375rem .75rem;transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;color: rgb(43, 41, 42);background-color: rgb(4, 149, 61);border-color: rgb(216, 41, 38);height: 44px;width: 174px;">activate
+    <a href={{activation_link}}> <button type=" button" class="btn btn-primary" style="box-sizing: border-box;border-radius: 4px;margin: 0;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;overflow: visible;text-transform: none;-webkit-appearance: button;display: inline-block;font-weight: 400;text-align: center;white-space: nowrap;vertical-align: middle;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;border: 1px solid transparent;padding: .375rem .75rem;transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;color: rgb(43, 41, 42);background-color: rgb(4, 149, 61);border-color: rgb(11, 73, 35);height: 44px;width: 174px;">activate
             account</button></a>
 </div>
 {% endblock %}

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -1,0 +1,15 @@
+{% extends 'base_email.html' %}
+{% block content %}
+<div class="rectangle-3" style="box-sizing: border-box;margin: 60px 138px;">
+    <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important;">
+        Hello <strong>{{username}}</strong>. Click the button below to reset your password. If you did not request this
+        update,
+        please ignore this message.
+        <br>
+        <br>Regards,<br><strong>NCPWD Team</strong>
+    </p>
+</div>
+<div style="box-sizing: border-box;">
+    <a href={{reset_password_link}}> <button type=" button" class="btn btn-primary" style="box-sizing: border-box;border-radius: 4px;margin: 0;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;overflow: visible;text-transform: none;-webkit-appearance: button;display: inline-block;font-weight: 400;text-align: center;white-space: nowrap;vertical-align: middle;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;border: 1px solid transparent;padding: .375rem .75rem;transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;color: rgb(43, 41, 42);background-color: rgb(4, 149, 61);border-color: rgb(11, 73, 35);height: 44px;width: 174px;">Reset Password</button></a>
+</div>
+{% endblock %}

--- a/templates/success_password_reset.html
+++ b/templates/success_password_reset.html
@@ -1,0 +1,14 @@
+{% extends 'base_email.html' %}
+{% block content %}
+<div class="rectangle-3" style="box-sizing: border-box;margin: 60px 138px;">
+    <p class="invite" style="box-sizing: border-box;margin-top: 0;margin-bottom: 1rem;orphans: 3;widows: 3;color: #6d6d6d;line-height: 21px;font-family: 'DINPro', 'Roboto', sans-serif !important;">
+        Hello <strong>{{username}}</strong>. Your password has been <i style="color:rgb(4, 149, 61);"">successfully</i> reset. Click below to login to your NCPWD account.
+        Contact the administrator if you didnt request the change.
+        <br>
+        <br>Regards,<br><strong>NCPWD Team</strong>
+    </p>
+</div>
+<div style="box-sizing: border-box;">
+    <a href={{login_link}}> <button type=" button" class="btn btn-primary" style="box-sizing: border-box;border-radius: 4px;margin: 0;font-family: 'DINPro', 'Roboto', sans-serif;font-size: 1rem;overflow: visible;text-transform: none;-webkit-appearance: button;display: inline-block;font-weight: 400;text-align: center;white-space: nowrap;vertical-align: middle;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;border: 1px solid transparent;padding: .375rem .75rem;transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;color: rgb(43, 41, 42);background-color: rgb(4, 149, 61);border-color: rgb(11, 73, 35);height: 44px;width: 174px;">Login</button></a>
+</div>
+{% endblock %}


### PR DESCRIPTION
**What does this PR do?**

- [x] add forgot password view and serializer
- [x] add an email with a link to reset password
- [x] add reset password view and serializer
- [x] add password reset confirmation email
- [x] refactored email templates

**Any background context you want to provide or addition**

**How to test**

- clone this repo `git clone https://github.com/C3real-kill3r/NCPWD.git`
- checkout to this branch `git checkout ft-password-reset-167326110`
- run the server `python manage.py runserver`
- request a password reset `http://127.0.0.1:8000/api/password/forgot/`
```
{"email":"your_email@email.com"}
```
- note: the email but be for a registered user
- reset account `http://127.0.0.1:8000/api/password/reset/generated_token/`
```
{
	"email":"your_email@email.com",
	"password":"Try@1234",
	"confirm_password":"Try@1234"
}
```

- login with the new password `http://127.0.0.1:8000/api/users/login/`
```
{"user":{
	"email":"your_email@email.com",
	"password":"Try@1234"
}}
```

**What are the relevant pivotal tracker stories?**

[#167326110](https://www.pivotaltracker.com/story/show/167326110)

**Questions:**

If something is unclear or you want some questions to be addressed by your peers, mention them here